### PR TITLE
Fix issue with display:none in chrome and opera browsers for list of sponsors

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,7 +272,7 @@ layout: default
                 <div class="row">
                 {% for sponsor in site.data.sponsors %}
                     <div class="col-md-4 col-sm-6">
-                        <a href="{{ sponsor.website }}" class="sponsor-block">
+                        <a href="{{ sponsor.website }}">
                             <img src="{{ sponsor.logo }}" class="img-responsive img-centered" alt="{{ sponsor.name }}">
                         </a>
                     </div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -64,13 +64,6 @@ h6 {
     padding-bottom: 30px;
 }
 
-.sponsor-block {
-  width: 260px;
-  height: 160px;
-  display: flex;
-  margin: 0 auto;
-}
-
 .org-block {
     padding-top: 20px;
     padding-bottom: 20px;


### PR DESCRIPTION
Tested in browsers:

- chrome - Version 60.0.3112.113 (Official Build) (64-bit)

- safari - Version 11.0 (12604.1.38.1.7)

- firefox - 49.0.1